### PR TITLE
ci(build): setup Node.js and pnpm for WebRenderer plugin build

### DIFF
--- a/.github/workflows/Build and draft.yml
+++ b/.github/workflows/Build and draft.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 24
 
     - name: Setup pnpm
       uses: pnpm/action-setup@v4

--- a/.github/workflows/Build and draft.yml
+++ b/.github/workflows/Build and draft.yml
@@ -39,6 +39,17 @@ jobs:
       with:
         dotnet-version: 10.0.x
 
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 10.33.3
+        run_install: false
+
     - name: Resolve build options
       id: build_options
       shell: pwsh


### PR DESCRIPTION
WebRenderer 插件的 Host csproj 已自动执行 pnpm install --frozen-lockfile 与 pnpm run build，但 CI 缺少 pnpm/nodejs 环境，导致前端构建被静默跳过、产物缺失。补上 setup-node@v4 (node 24) 与 pnpm/action-setup@v4 (10.33.3，与 package.json 的 packageManager 字段对齐)。