### PR TITLE
Refactor namespaces from `neo_bpsys_wpf.PluginSdk` to `neo_bpsys_wpf.…

### DIFF
--- a/docs/frontend/fronted-designer-v3.md
+++ b/docs/frontend/fronted-designer-v3.md
@@ -325,7 +325,7 @@ v3 之后 PluginSdk 不再作为 NuGet 包发布。插件作者应 clone 本仓�
 
 | 类型 | 职责 |
 | --- | --- |
-| `FrontedV3ControlBase` | 所有 v3 控件的抽象基类（继承 `UserControl`），定义在 Core 程序集，命名空间为 `neo_bpsys_wpf.PluginSdk`。控件不管理根布局。 |
+| `FrontedV3ControlBase` | 所有 v3 控件的抽象基类（继承 `UserControl`），定义在 Core 程序集，命名空间 `neo_bpsys_wpf.Core.Abstractions.Services`。控件不管理根布局。 |
 | `[FrontedV3Control("ControlId", IsBuiltIn = bool)]` | 标注控件类型，携带局部标识与内置标记。 |
 | `FrontedV3ControlRegistration` | 注册记录，包含 `CanonicalControlType`、`ControlType`、`ConfigType`、`Properties`、`CreateDefaultConfig`、`StyleTransfer` 能力声明。 |
 | `FrontedV3ControlRegistry` / `IFrontedV3ControlRegistry` | 统一注册表，从 DI 收集所有 `FrontedV3ControlRegistration` 并按 `CanonicalControlType` 索引。 |

--- a/docs/plugin/plugin-development.md
+++ b/docs/plugin/plugin-development.md
@@ -90,7 +90,7 @@ Canonical Control Type 由 `ControlId` 和来源自动推导：
 
 ### 创建控件
 
-控件类继承 `FrontedV3ControlBase`（定义在 Core 程序集，命名空间为 `neo_bpsys_wpf.PluginSdk` 以保持插件 API 兼容）。该基类继承自 `UserControl`，支持 XAML 声明式视觉树。宿主在创建后通过 `InitializeFrontedV3` 注入运行时上下文，控件通过 `Context` 访问服务、共享数据、资源解析器与当前配置。
+控件类继承 `FrontedV3ControlBase`（定义在 Core 程序集，命名空间 `neo_bpsys_wpf.Core.Abstractions.Services`）。该基类继承自 `UserControl`，支持 XAML 声明式视觉树。宿主在创建后通过 `InitializeFrontedV3` 注入运行时上下文，控件通过 `Context` 访问服务、共享数据、资源解析器与当前配置。
 
 控件 **不** 管理自身的 Canvas 坐标（`Left`/`Top`/`Width`/`Height`/`ZIndex`/`Visibility`/`GaussianBlur`），这些由 `FrontedV3ControlHost` 统一负责。控件只负责矩形区域内的视觉内容。
 

--- a/docs/plugin/plugin-system.md
+++ b/docs/plugin/plugin-system.md
@@ -110,7 +110,7 @@ plugin:plfjy.ExamplePlugin/TeamCard
 
 ### 创建与注册控件
 
-插件控件必须继承 `FrontedV3ControlBase`（定义在 Core 程序集，命名空间为 `neo_bpsys_wpf.PluginSdk`）并标注 `[FrontedV3Control("ControlId")]`：
+插件控件必须继承 `FrontedV3ControlBase`（定义在 Core 程序集，命名空间 `neo_bpsys_wpf.Core.Abstractions.Services`）并标注 `[FrontedV3Control("ControlId")]`：
 
 ```csharp
 [FrontedV3Control("TeamCard")]

--- a/neo-bpsys-wpf.Core/Abstractions/Services/FrontedV3ControlAttribute.cs
+++ b/neo-bpsys-wpf.Core/Abstractions/Services/FrontedV3ControlAttribute.cs
@@ -1,4 +1,4 @@
-namespace neo_bpsys_wpf.PluginSdk;
+namespace neo_bpsys_wpf.Core.Abstractions.Services;
 
 /// <summary>
 /// 标注一个 v3 前台控件类型，并携带控件局部标识（ControlId）与 Designer 展示元数据。
@@ -27,9 +27,6 @@ namespace neo_bpsys_wpf.PluginSdk;
 /// 由 Attribute 直接声明，注册时通过 <c>FrontedV3ControlRegistryExtensions.BuildMetadata</c>
 /// 推导为 <c>FrontedV3ControlMetadata</c> 暴露到 Registration。
 /// 所有元数据字段可选，缺失时由调用方按合理默认值回退。
-/// </para>
-/// <para>
-/// 该类型定义在 Core 程序集中（命名空间 <c>neo_bpsys_wpf.PluginSdk</c> 以保持插件 API 兼容）。
 /// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]

--- a/neo-bpsys-wpf.Core/Abstractions/Services/FrontedV3ControlBase.cs
+++ b/neo-bpsys-wpf.Core/Abstractions/Services/FrontedV3ControlBase.cs
@@ -1,9 +1,8 @@
 using System.ComponentModel;
 using System.Windows.Controls;
-using neo_bpsys_wpf.Core.Abstractions.Services;
 using neo_bpsys_wpf.Core.Models.FrontedLayout.V3.Options;
 
-namespace neo_bpsys_wpf.PluginSdk;
+namespace neo_bpsys_wpf.Core.Abstractions.Services;
 
 /// <summary>
 /// v3 前台控件的抽象基类，所有新注册的 v3 控件必须继承自此类型。
@@ -31,10 +30,6 @@ namespace neo_bpsys_wpf.PluginSdk;
 /// <c>{Binding Options.Appearance.TextColor}</c> 最终委托到对应
 /// <see cref="neo_bpsys_wpf.Core.Models.FrontedLayout.V3.Properties.FrontedV3PropertyDefinition"/> 的 Storage 访问器，
 /// 读写直接作用于当前 <see cref="Core.Models.FrontedLayout.FrontedControlConfigBase"/>，不缓存独立值。
-/// </para>
-/// <para>
-/// 该类型定义在 Core 程序集中（命名空间 <c>neo_bpsys_wpf.PluginSdk</c> 以保持插件 API 兼容），
-/// 使内置控件（也在 Core 中）能够直接继承，避免 Core → PluginSdk 的循环引用。
 /// </para>
 /// </remarks>
 public abstract class FrontedV3ControlBase : UserControl

--- a/neo-bpsys-wpf.Core/Abstractions/Services/FrontedV3PartVisualAttribute.cs
+++ b/neo-bpsys-wpf.Core/Abstractions/Services/FrontedV3PartVisualAttribute.cs
@@ -1,4 +1,4 @@
-namespace neo_bpsys_wpf.PluginSdk;
+namespace neo_bpsys_wpf.Core.Abstractions.Services;
 
 /// <summary>
 /// 标注控件上返回固定 Part Visual 的属性，用于 C# 代码声明 Part Visual。
@@ -25,9 +25,6 @@ namespace neo_bpsys_wpf.PluginSdk;
 /// <item>声明了 Part 但未找到对应 Visual → 输出 warning，不崩溃 Designer。</item>
 /// <item>多个 Visual 映射到同一个 PartId → 输出 warning，使用第一个匹配项。</item>
 /// </list>
-/// </para>
-/// <para>
-/// 该类型定义在 Core 程序集中（命名空间 <c>neo_bpsys_wpf.PluginSdk</c> 以保持插件 API 兼容）。
 /// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]

--- a/neo-bpsys-wpf.Core/Extensions/Registry/FrontedV3BuiltInControlRegistryExtensions.cs
+++ b/neo-bpsys-wpf.Core/Extensions/Registry/FrontedV3BuiltInControlRegistryExtensions.cs
@@ -8,7 +8,7 @@ using neo_bpsys_wpf.Core.Services.FrontedLayout.V3;
 using neo_bpsys_wpf.Core.Services.FrontedLayout.V3.Parts;
 using neo_bpsys_wpf.Core.Services.FrontedLayout.V3.Properties;
 using neo_bpsys_wpf.Core.Services.Registry;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 
 namespace neo_bpsys_wpf.Core.Extensions.Registry;
 

--- a/neo-bpsys-wpf.Core/Extensions/Registry/FrontedV3ControlRegistryExtensions.cs
+++ b/neo-bpsys-wpf.Core/Extensions/Registry/FrontedV3ControlRegistryExtensions.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using neo_bpsys_wpf.Core.Models.FrontedLayout;
 using neo_bpsys_wpf.Core.Models.FrontedLayout.V3;
 using neo_bpsys_wpf.Core.Models.FrontedLayout.V3.Parts;
@@ -8,7 +9,7 @@ using neo_bpsys_wpf.Core.Services.FrontedLayout.V3;
 using neo_bpsys_wpf.Core.Services.FrontedLayout.V3.Parts;
 using neo_bpsys_wpf.Core.Services.Registry;
 
-namespace neo_bpsys_wpf.PluginSdk;
+namespace neo_bpsys_wpf.Core.Extensions.Registry;
 
 /// <summary>
 /// v3 前台控件注册扩展方法。
@@ -25,8 +26,8 @@ namespace neo_bpsys_wpf.PluginSdk;
 /// 框架在注册时通过反射发现并转换为 <see cref="FrontedV3PropertyDefinition"/>。
 /// </para>
 /// <para>
-/// 本类型定义在 Core 程序集，命名空间为 <c>neo_bpsys_wpf.PluginSdk</c> 以保持插件 API 兼容。
-/// PluginSdk 项目本身只是构建期空壳（提供 .targets 与打包工具），不携带运行时程序集。
+/// PluginSdk 项目本身只是构建期空壳（提供 .targets 与打包工具），不携带运行时程序集；
+/// 所有插件 API 类型均定义在 Core 程序集中。
 /// </para>
 /// </remarks>
 public static class FrontedV3ControlRegistryExtensions

--- a/neo-bpsys-wpf.Core/Services/FrontedLayout/BackgroundTintPolygonFrontedControl.cs
+++ b/neo-bpsys-wpf.Core/Services/FrontedLayout/BackgroundTintPolygonFrontedControl.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using neo_bpsys_wpf.Core.Abstractions.Services;
 using neo_bpsys_wpf.Core.Models.FrontedLayout;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using System.Windows;
 using System.Windows.Media;
 

--- a/neo-bpsys-wpf.Core/Services/FrontedLayout/BackgroundTintRectangleFrontedControl.cs
+++ b/neo-bpsys-wpf.Core/Services/FrontedLayout/BackgroundTintRectangleFrontedControl.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using neo_bpsys_wpf.Core.Abstractions.Services;
 using neo_bpsys_wpf.Core.Models.FrontedLayout;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using System.Windows;
 using System.Windows.Media;
 

--- a/neo-bpsys-wpf.Core/Services/FrontedLayout/BorderedImageFrontedControl.cs
+++ b/neo-bpsys-wpf.Core/Services/FrontedLayout/BorderedImageFrontedControl.cs
@@ -1,6 +1,6 @@
 using neo_bpsys_wpf.Core.Abstractions.Services;
 using neo_bpsys_wpf.Core.Models.FrontedLayout;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using System.Windows;
 using System.Windows.Controls;
 

--- a/neo-bpsys-wpf.Core/Services/FrontedLayout/ImageFrontedControl.cs
+++ b/neo-bpsys-wpf.Core/Services/FrontedLayout/ImageFrontedControl.cs
@@ -1,6 +1,6 @@
 using neo_bpsys_wpf.Core.Abstractions.Services;
 using neo_bpsys_wpf.Core.Models.FrontedLayout;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using System.Windows.Controls;
 
 namespace neo_bpsys_wpf.Core.Services.FrontedLayout;

--- a/neo-bpsys-wpf.Core/Services/FrontedLayout/PolygonFrontedControl.cs
+++ b/neo-bpsys-wpf.Core/Services/FrontedLayout/PolygonFrontedControl.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Logging;
 using neo_bpsys_wpf.Core.Abstractions.Services;
 using neo_bpsys_wpf.Core.Models.FrontedLayout;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using System.Windows;
 using System.Windows.Media;
 using Polygon = System.Windows.Shapes.Polygon;

--- a/neo-bpsys-wpf.Core/Services/FrontedLayout/RectangleFrontedControl.cs
+++ b/neo-bpsys-wpf.Core/Services/FrontedLayout/RectangleFrontedControl.cs
@@ -1,6 +1,6 @@
 using neo_bpsys_wpf.Core.Abstractions.Services;
 using neo_bpsys_wpf.Core.Models.FrontedLayout;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using System.Windows;
 using Rectangle = System.Windows.Shapes.Rectangle;
 

--- a/neo-bpsys-wpf.Core/Services/FrontedLayout/TextFrontedControl.cs
+++ b/neo-bpsys-wpf.Core/Services/FrontedLayout/TextFrontedControl.cs
@@ -1,6 +1,6 @@
 using neo_bpsys_wpf.Core.Abstractions.Services;
 using neo_bpsys_wpf.Core.Models.FrontedLayout;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;

--- a/neo-bpsys-wpf.Core/Services/FrontedLayout/V3/FrontedV3ControlHost.cs
+++ b/neo-bpsys-wpf.Core/Services/FrontedLayout/V3/FrontedV3ControlHost.cs
@@ -10,7 +10,7 @@ using neo_bpsys_wpf.Core.Models.FrontedLayout;
 using neo_bpsys_wpf.Core.Models.FrontedLayout.V3;
 using neo_bpsys_wpf.Core.Services.FrontedLayout.V3.Geometry;
 using neo_bpsys_wpf.Core.Services.FrontedLayout.V3.Parts;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 
 namespace neo_bpsys_wpf.Core.Services.FrontedLayout.V3;
 

--- a/neo-bpsys-wpf.ExamplePlugin/ExamplePlugin.cs
+++ b/neo-bpsys-wpf.ExamplePlugin/ExamplePlugin.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Hosting;
 using neo_bpsys_wpf.Core.Abstractions;
 using neo_bpsys_wpf.Core.Extensions.Registry;
 using neo_bpsys_wpf.Core.Helpers;
-using neo_bpsys_wpf.PluginSdk;
 using neo_bpsys_wpf.ExamplePlugin.Models;
 using neo_bpsys_wpf.ExamplePlugin.Services;
 using neo_bpsys_wpf.ExamplePlugin.Views;

--- a/neo-bpsys-wpf.ExamplePlugin/StatusBadgeControl.cs
+++ b/neo-bpsys-wpf.ExamplePlugin/StatusBadgeControl.cs
@@ -5,7 +5,7 @@ using neo_bpsys_wpf.Core.Abstractions.Services;
 using neo_bpsys_wpf.Core.Models.FrontedLayout.V3.Properties;
 using neo_bpsys_wpf.Core.Models.FrontedLayout.V3.StyleTransfer;
 using neo_bpsys_wpf.Core.Services.FrontedLayout.V3;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 
 namespace neo_bpsys_wpf.ExamplePlugin;
 

--- a/neo-bpsys-wpf.ExamplePlugin/TeamCardControl.xaml
+++ b/neo-bpsys-wpf.ExamplePlugin/TeamCardControl.xaml
@@ -5,7 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="clr-namespace:neo_bpsys_wpf.ExamplePlugin"
-    xmlns:pluginSdk="clr-namespace:neo_bpsys_wpf.PluginSdk;assembly=neo-bpsys-wpf.Core"
+    xmlns:pluginSdk="clr-namespace:neo_bpsys_wpf.Core.Abstractions.Services;assembly=neo-bpsys-wpf.Core"
     xmlns:fronted="clr-namespace:neo_bpsys_wpf.Core.Models.FrontedLayout.V3;assembly=neo-bpsys-wpf.Core"
     mc:Ignorable="d"
     d:DataContext="{d:DesignInstance Type=local:TeamCardDesignContext, IsDesignTimeCreatable=True}">

--- a/neo-bpsys-wpf.ExamplePlugin/TeamCardControl.xaml.cs
+++ b/neo-bpsys-wpf.ExamplePlugin/TeamCardControl.xaml.cs
@@ -4,7 +4,7 @@ using neo_bpsys_wpf.Core.Models.FrontedLayout.V3.Properties;
 using neo_bpsys_wpf.Core.Models.FrontedLayout.V3.StyleTransfer;
 using neo_bpsys_wpf.Core.Services.FrontedLayout.V3;
 using neo_bpsys_wpf.Core.Services.FrontedLayout.V3.Parts;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 
 namespace neo_bpsys_wpf.ExamplePlugin;
 

--- a/neo-bpsys-wpf.Tests/Models/BackgroundTintFrontedControlTest.cs
+++ b/neo-bpsys-wpf.Tests/Models/BackgroundTintFrontedControlTest.cs
@@ -11,7 +11,7 @@ using neo_bpsys_wpf.Core.Models.FrontedLayout.V3.Options;
 using neo_bpsys_wpf.Core.Models.FrontedLayout.V3.Properties;
 using neo_bpsys_wpf.Core.Services.FrontedLayout;
 using neo_bpsys_wpf.Core.Services.FrontedLayout.V3;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using neo_bpsys_wpf.Tests.Infrastructure;
 using neo_bpsys_wpf.ViewModels.Windows;
 using System;

--- a/neo-bpsys-wpf.Tests/Models/FrontedCanvasConfigTest.cs
+++ b/neo-bpsys-wpf.Tests/Models/FrontedCanvasConfigTest.cs
@@ -15,7 +15,7 @@ using neo_bpsys_wpf.Core.Models.FrontedLayout.V3.Properties;
 using neo_bpsys_wpf.Core.Models.ScoreSystem;
 using neo_bpsys_wpf.Core.Services.FrontedLayout;
 using neo_bpsys_wpf.Core.Services.FrontedLayout.V3;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using neo_bpsys_wpf.Tests.Infrastructure;
 using System;
 using System.Collections.Generic;

--- a/neo-bpsys-wpf.Tests/Models/FrontedV3ControlRegistrationTest.cs
+++ b/neo-bpsys-wpf.Tests/Models/FrontedV3ControlRegistrationTest.cs
@@ -6,13 +6,13 @@ using System.Linq;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using neo_bpsys_wpf.Core.Abstractions.Services;
+using neo_bpsys_wpf.Core.Extensions.Registry;
 using neo_bpsys_wpf.Core.Models.FrontedLayout;
 using neo_bpsys_wpf.Core.Models.FrontedLayout.V3;
 using neo_bpsys_wpf.Core.Models.FrontedLayout.V3.Options;
 using neo_bpsys_wpf.Core.Models.FrontedLayout.V3.Properties;
 using neo_bpsys_wpf.Core.Services.FrontedLayout.V3;
 using neo_bpsys_wpf.Core.Services.Registry;
-using neo_bpsys_wpf.PluginSdk;
 using Xunit;
 
 namespace neo_bpsys_wpf.Tests.Models;

--- a/neo-bpsys-wpf.Tests/Services/FrontedLayoutPluginDependencyPackageTest.cs
+++ b/neo-bpsys-wpf.Tests/Services/FrontedLayoutPluginDependencyPackageTest.cs
@@ -15,7 +15,7 @@ using neo_bpsys_wpf.Core.Services.FrontedLayout.V3;
 using neo_bpsys_wpf.Core.Services.Registry;
 using neo_bpsys_wpf.ExamplePlugin;
 using neo_bpsys_wpf.Models.Plugins;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using neo_bpsys_wpf.Services.Abstractions;
 using neo_bpsys_wpf.Tests.Infrastructure;
 using neo_bpsys_wpf.ViewModels.Pages;

--- a/neo-bpsys-wpf.Tests/Services/FrontedRendererBehaviorGuidTest.cs
+++ b/neo-bpsys-wpf.Tests/Services/FrontedRendererBehaviorGuidTest.cs
@@ -8,7 +8,7 @@ using neo_bpsys_wpf.Core.Models.FrontedLayout.V3;
 using neo_bpsys_wpf.Core.Models.FrontedLayout.V3.Properties;
 using neo_bpsys_wpf.Core.Services.FrontedLayout;
 using neo_bpsys_wpf.Core.Services.FrontedLayout.V3;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using neo_bpsys_wpf.Tests.Infrastructure;
 using System;
 using System.Windows;

--- a/neo-bpsys-wpf.Tests/Services/FrontedV3ControlHostTest.cs
+++ b/neo-bpsys-wpf.Tests/Services/FrontedV3ControlHostTest.cs
@@ -8,7 +8,7 @@ using neo_bpsys_wpf.Core.Models.FrontedLayout.V3.Options;
 using neo_bpsys_wpf.Core.Models.FrontedLayout.V3.Properties;
 using neo_bpsys_wpf.Core.Services.FrontedLayout;
 using neo_bpsys_wpf.Core.Services.FrontedLayout.V3;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using neo_bpsys_wpf.Tests.Infrastructure;
 using System;
 using System.Linq;

--- a/neo-bpsys-wpf.Tests/Services/FrontedV3PartTest.cs
+++ b/neo-bpsys-wpf.Tests/Services/FrontedV3PartTest.cs
@@ -11,7 +11,7 @@ using neo_bpsys_wpf.Core.Models.FrontedLayout.V3.Parts;
 using neo_bpsys_wpf.Core.Services.FrontedLayout.V3;
 using neo_bpsys_wpf.Core.Services.FrontedLayout.V3.Geometry;
 using neo_bpsys_wpf.Core.Services.FrontedLayout.V3.Parts;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using neo_bpsys_wpf.Tests.Infrastructure;
 using neo_bpsys_wpf.ViewModels.Windows;
 using Xunit;

--- a/neo-bpsys-wpf.Tests/Services/FrontedV3PartVisualRuntimeBinderTest.cs
+++ b/neo-bpsys-wpf.Tests/Services/FrontedV3PartVisualRuntimeBinderTest.cs
@@ -9,7 +9,7 @@ using neo_bpsys_wpf.Core.Models.FrontedLayout.V3.Parts;
 using neo_bpsys_wpf.Core.Models.FrontedLayout.V3.Properties;
 using neo_bpsys_wpf.Core.Services.FrontedLayout.V3;
 using neo_bpsys_wpf.Core.Services.FrontedLayout.V3.Parts;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using neo_bpsys_wpf.Tests.Infrastructure;
 using System;
 using System.Linq;

--- a/neo-bpsys-wpf.Tests/Services/V3OptionsSourceGeneratorIdentifierTest.cs
+++ b/neo-bpsys-wpf.Tests/Services/V3OptionsSourceGeneratorIdentifierTest.cs
@@ -51,7 +51,7 @@ public class V3OptionsSourceGeneratorIdentifierTest
             }
         }
 
-        namespace neo_bpsys_wpf.PluginSdk
+        namespace neo_bpsys_wpf.Core.Abstractions.Services
         {
             [AttributeUsage(AttributeTargets.Class)]
             public sealed class FrontedV3ControlAttribute : Attribute
@@ -78,7 +78,7 @@ public class V3OptionsSourceGeneratorIdentifierTest
 
             namespace TestPlugin
             {
-                [neo_bpsys_wpf.PluginSdk.FrontedV3Control("Team Card")]
+                [neo_bpsys_wpf.Core.Abstractions.Services.FrontedV3Control("Team Card")]
                 public sealed class TeamCardControl
                 {
                     public static readonly FrontedV3Property<string> TextProperty =
@@ -116,7 +116,7 @@ public class V3OptionsSourceGeneratorIdentifierTest
 
             namespace TestPlugin
             {
-                [neo_bpsys_wpf.PluginSdk.FrontedV3Control("Test")]
+                [neo_bpsys_wpf.Core.Abstractions.Services.FrontedV3Control("Test")]
                 public sealed class TestControl
                 {
                     public static readonly FrontedV3Property<string> ValueProperty =
@@ -147,7 +147,7 @@ public class V3OptionsSourceGeneratorIdentifierTest
 
             namespace TestPlugin
             {
-                [neo_bpsys_wpf.PluginSdk.FrontedV3Control("Test")]
+                [neo_bpsys_wpf.Core.Abstractions.Services.FrontedV3Control("Test")]
                 public sealed class TestControl
                 {
                     public static readonly FrontedV3Property<string> FirstProperty =
@@ -180,7 +180,7 @@ public class V3OptionsSourceGeneratorIdentifierTest
 
             namespace TestPlugin
             {
-                [neo_bpsys_wpf.PluginSdk.FrontedV3Control("Test")]
+                [neo_bpsys_wpf.Core.Abstractions.Services.FrontedV3Control("Test")]
                 public sealed class TestControl
                 {
                     public static readonly FrontedV3Property<string> ValueProperty =
@@ -210,7 +210,7 @@ public class V3OptionsSourceGeneratorIdentifierTest
 
             namespace TestPlugin
             {
-                [neo_bpsys_wpf.PluginSdk.FrontedV3Control("Test")]
+                [neo_bpsys_wpf.Core.Abstractions.Services.FrontedV3Control("Test")]
                 public sealed class TestControl
                 {
                     public static readonly FrontedV3Property<string> ValueProperty =
@@ -240,7 +240,7 @@ public class V3OptionsSourceGeneratorIdentifierTest
 
             namespace TestPlugin
             {
-                [neo_bpsys_wpf.PluginSdk.FrontedV3Control("Team Card")]
+                [neo_bpsys_wpf.Core.Abstractions.Services.FrontedV3Control("Team Card")]
                 public sealed class TeamCardControl
                 {
                     public static readonly FrontedV3Property<string> TextProperty =
@@ -268,7 +268,7 @@ public class V3OptionsSourceGeneratorIdentifierTest
         var source = $$"""
             using neo_bpsys_wpf.Core.Models.FrontedLayout.V3.Properties;
 
-            [neo_bpsys_wpf.PluginSdk.FrontedV3Control("Test")]
+            [neo_bpsys_wpf.Core.Abstractions.Services.FrontedV3Control("Test")]
             public sealed class TestControl
             {
                 public static readonly FrontedV3Property<string> TextProperty =
@@ -297,7 +297,7 @@ public class V3OptionsSourceGeneratorIdentifierTest
 
             namespace TestPlugin
             {
-                [neo_bpsys_wpf.PluginSdk.FrontedV3Control("1Card")]
+                [neo_bpsys_wpf.Core.Abstractions.Services.FrontedV3Control("1Card")]
                 public sealed class FirstCardControl
                 {
                     public static readonly FrontedV3Property<string> TextProperty =

--- a/neo-bpsys-wpf.V3SourceGenerator/V3OptionsSourceGenerator.cs
+++ b/neo-bpsys-wpf.V3SourceGenerator/V3OptionsSourceGenerator.cs
@@ -35,7 +35,7 @@ namespace neo_bpsys_wpf.V3SourceGenerator;
 public sealed class V3OptionsSourceGenerator : IIncrementalGenerator
 {
     private const string FrontedV3ControlAttributeFullName =
-        "neo_bpsys_wpf.PluginSdk.FrontedV3ControlAttribute";
+        "neo_bpsys_wpf.Core.Abstractions.Services.FrontedV3ControlAttribute";
 
     private const string FrontedV3PropertyNamespace =
         "neo_bpsys_wpf.Core.Models.FrontedLayout.V3.Properties";

--- a/neo-bpsys-wpf/Controls/FrontedLayout/GameProgressTextFrontedControl.cs
+++ b/neo-bpsys-wpf/Controls/FrontedLayout/GameProgressTextFrontedControl.cs
@@ -7,7 +7,7 @@ using neo_bpsys_wpf.Core.Helpers;
 using neo_bpsys_wpf.Core.Models;
 using neo_bpsys_wpf.Core.Models.FrontedLayout;
 using neo_bpsys_wpf.Helpers;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using System.ComponentModel;
 using System.Globalization;
 using System.Windows;

--- a/neo-bpsys-wpf/Controls/FrontedLayout/GlobalScoreRowFrontedControl.cs
+++ b/neo-bpsys-wpf/Controls/FrontedLayout/GlobalScoreRowFrontedControl.cs
@@ -3,7 +3,7 @@ using neo_bpsys_wpf.Core.Abstractions.Services;
 using neo_bpsys_wpf.Core.Models.FrontedLayout;
 using neo_bpsys_wpf.Core.Models.ScoreSystem;
 using neo_bpsys_wpf.Core.Services.FrontedLayout;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;

--- a/neo-bpsys-wpf/Controls/FrontedLayout/LocalizedTextFrontedControl.cs
+++ b/neo-bpsys-wpf/Controls/FrontedLayout/LocalizedTextFrontedControl.cs
@@ -5,7 +5,7 @@ using neo_bpsys_wpf.Core.Events;
 using neo_bpsys_wpf.Core.Models.FrontedLayout;
 using neo_bpsys_wpf.Core.Services.FrontedLayout;
 using neo_bpsys_wpf.Helpers;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using System.ComponentModel;
 using System.Globalization;
 using System.Windows;

--- a/neo-bpsys-wpf/Controls/FrontedLayout/MapNameTextFrontedControl.cs
+++ b/neo-bpsys-wpf/Controls/FrontedLayout/MapNameTextFrontedControl.cs
@@ -5,7 +5,7 @@ using neo_bpsys_wpf.Core.Enums;
 using neo_bpsys_wpf.Core.Events;
 using neo_bpsys_wpf.Core.Models.FrontedLayout;
 using neo_bpsys_wpf.Helpers;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;

--- a/neo-bpsys-wpf/Controls/FrontedLayout/MapV2DisplayFrontedControl.cs
+++ b/neo-bpsys-wpf/Controls/FrontedLayout/MapV2DisplayFrontedControl.cs
@@ -6,7 +6,7 @@ using neo_bpsys_wpf.Core.Models;
 using neo_bpsys_wpf.Core.Models.FrontedLayout;
 using neo_bpsys_wpf.Core.Models.FrontedLayout.Behaviors;
 using neo_bpsys_wpf.Core.Services.FrontedLayout;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;

--- a/neo-bpsys-wpf/Controls/FrontedLayout/TalentTraitDisplayFrontedControl.cs
+++ b/neo-bpsys-wpf/Controls/FrontedLayout/TalentTraitDisplayFrontedControl.cs
@@ -5,7 +5,7 @@ using neo_bpsys_wpf.Core.Enums;
 using neo_bpsys_wpf.Core.Helpers;
 using neo_bpsys_wpf.Core.Models;
 using neo_bpsys_wpf.Core.Models.FrontedLayout;
-using neo_bpsys_wpf.PluginSdk;
+using neo_bpsys_wpf.Core.Abstractions.Services;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;


### PR DESCRIPTION
…Core.Abstractions.Services`

- Updated documentation references and code comments to reflect the new namespace structure.
- Modified all relevant files to use the new namespace for `FrontedV3ControlBase`, `FrontedV3ControlAttribute`, and related classes.
- Ensured compatibility of plugin development and control registration processes with the updated namespace.